### PR TITLE
fixed login view issue that did not update the error message

### DIFF
--- a/src/main/java/use_cases/log_in/gui/view/LoginView.java
+++ b/src/main/java/use_cases/log_in/gui/view/LoginView.java
@@ -211,6 +211,8 @@ public class LoginView extends View implements ActionListener, PropertyChangeLis
      */
     public void displayErrorMessage(String message) {
         errorMessageLabel.setText(message);
+        errorMessageLabel.revalidate();
+        errorMessageLabel.repaint();
     }
 
     /**

--- a/src/main/java/use_cases/log_in/interface_adapter/presenter/LoginPresenter.java
+++ b/src/main/java/use_cases/log_in/interface_adapter/presenter/LoginPresenter.java
@@ -55,5 +55,7 @@ public class LoginPresenter implements LoginOutputBoundary {
     public void prepareFailView(String errorMessage) {
         // Update the view model with the error message
         loginViewModel.setErrorMessage(errorMessage);
+        loginViewModel.firePropertyChange("errorMessage", null, errorMessage);
+        System.out.println("asdad");
     }
 }

--- a/src/main/java/use_cases/log_in/interface_adapter/view_model/LoginViewModel.java
+++ b/src/main/java/use_cases/log_in/interface_adapter/view_model/LoginViewModel.java
@@ -52,7 +52,6 @@ public class LoginViewModel extends ViewModel {
     public void setErrorMessage(String errorMessage) {
         String oldErrorMessage = this.errorMessage;
         this.errorMessage = errorMessage;
-        support.firePropertyChange("errorMessage", oldErrorMessage, errorMessage);
     }
 
     /**

--- a/src/main/java/use_cases/sign_up/gui/view/SignUpView.java
+++ b/src/main/java/use_cases/sign_up/gui/view/SignUpView.java
@@ -216,11 +216,15 @@ public class SignUpView extends View implements ActionListener, PropertyChangeLi
     public void displayErrorMessage(String message) {
         errorMessageLabel.setText(message);
         errorMessageLabel.setForeground(errorRed);
+        errorMessageLabel.revalidate();
+        errorMessageLabel.repaint();
     }
 
     public void displaySuccessMessage(String message) {
         errorMessageLabel.setText(message);
         errorMessageLabel.setForeground(successGreen);
+        errorMessageLabel.revalidate();
+        errorMessageLabel.repaint();
     }
 
     @Override


### PR DESCRIPTION
There was remaining issue with login, signup view.
The error message was not showing up when I switch between log in and sign up view repeatedly.
This is fixed now.