### PR TITLE
Remove repeats from recently viewed recipes, also swaps the order of the recentlyViewedRecipes list

### DIFF
--- a/src/main/java/entity/User.java
+++ b/src/main/java/entity/User.java
@@ -72,10 +72,22 @@ public class User {
     public void setPreference(Map<String, Object> preference) {this.preference = preference;}
     public void setRecentlyViewedRecipes(List<Recipe> recentlyViewedRecipes) {this.recentlyViewedRecipes = recentlyViewedRecipes;}
     public void addRecentlyViewedRecipe(Recipe recipe) {
-        if (this.recentlyViewedRecipes.size() >= 5) {
-            this.recentlyViewedRecipes.remove(0);
+        boolean seenBefore = false;
+        Recipe seenRecipe = null;
+        for (Recipe r : this.recentlyViewedRecipes) {
+            if (recipe.getName().equals(r.getName()) &&
+                    recipe.getInstructions().equals(r.getInstructions())) {
+                seenBefore = true;
+                seenRecipe = r;
+                break;
+            }
         }
-        this.recentlyViewedRecipes.add(recipe);
+        if (seenBefore) {
+            this.recentlyViewedRecipes.remove(seenRecipe);
+        } else if (this.recentlyViewedRecipes.size() >= 5) {
+            this.recentlyViewedRecipes.removeLast();
+        }
+        this.recentlyViewedRecipes.addFirst(recipe);
     }
 
     /**

--- a/src/main/java/entity/User.java
+++ b/src/main/java/entity/User.java
@@ -84,7 +84,7 @@ public class User {
         }
         if (seenBefore) {
             this.recentlyViewedRecipes.remove(seenRecipe);
-        } else if (this.recentlyViewedRecipes.size() >= 5) {
+        } else if (this.recentlyViewedRecipes.size() == 5) {
             this.recentlyViewedRecipes.removeLast();
         }
         this.recentlyViewedRecipes.addFirst(recipe);


### PR DESCRIPTION
swaps the order so that the most recently viewed recipe is shown at the top of the list, rather than at the bottom.

removes repeat recipe if it matches the same name and instructions as the recipe (couldnt do a direct match for the recipe since the ids are different for different instances of the same recipe). removes the occurence already in the list and adds the recipe again but to the top (since it was viewed most recently).